### PR TITLE
fix: replace windows line endings

### DIFF
--- a/bin/react-undraw-cli
+++ b/bin/react-undraw-cli
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
 const path = require('path');
-const file = path.join(__dirname, '../', 'scripts', 'build.js')
+const file = path.join(__dirname, '../', 'scripts', 'build.js');
 
 require(file);


### PR DESCRIPTION
## Description
Fixes #53 - `bin/react-undraw-cli` is in windows line ending style so when we wanna run this on UNIX machines, we've got:

```
react-undraw-cli
/usr/bin/env: ‘node\r’: No such file or directory
error Command failed with exit code 127.
```

## Checklist
Please ensure your pull request fulfills the following requirements:

- [x] The commit messages follow our guidelines ([CONTRIBUTING.md](./CONTRIBUTING.md)).
- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## Type
What kind of change does this pull request introduce?


```
[x] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Build related changes.
[ ] CI related changes.
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes
Does this pull request introduce any breaking changes?

<!-- please check the one that applies using an "x" -->
```
[ ] Yes
[x] No
```

<!-- if "Yes", please describe the impact and migration path for existing applications below -->

## Other Information
<!-- please include any additional information that might be helpful during review -->
n/a
